### PR TITLE
replaced homebrew onepass-connect chart with official chart and fixed…

### DIFF
--- a/clusters/cluster0/flux-system/sources/kustomization.yaml
+++ b/clusters/cluster0/flux-system/sources/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
   - cert-manager-repo.yaml
   - velero.yaml
   - external-secrets-repo.yaml
-  - bjw-s-repo.yaml
+  - onepass-repo.yaml
   - csi-secrets-store-repo.yaml

--- a/clusters/cluster0/flux-system/sources/onepass-repo.yaml
+++ b/clusters/cluster0/flux-system/sources/onepass-repo.yaml
@@ -1,9 +1,9 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: bjw-s
+  name: onepass
   namespace: flux-system
 spec:
-  type: oci
+  # type: oci
   interval: 5m
-  url: oci://ghcr.io/bjw-s/helm
+  url: https://1password.github.io/connect-helm-charts

--- a/clusters/cluster0/kubernetes/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
@@ -7,11 +7,11 @@ spec:
   interval: 30m
   chart:
     spec:
-      chart: app-template
-      version: 3.6.1
+      chart: connect
+      version: 2.0.5
       sourceRef:
         kind: HelmRepository
-        name: bjw-s
+        name: onepass
         namespace: flux-system
   install:
     remediation:
@@ -22,105 +22,410 @@ spec:
       strategy: rollback
       retries: 3
   values:
-    controllers:
-      onepassword-connect:
-        strategy: RollingUpdate
-        annotations:
-          reloader.stakater.com/auto: "true"
-        containers:
-          api:
-            image:
-              repository: docker.io/1password/connect-api
-              tag: 1.7.3@sha256:0601c7614e102eada268dbda6ba4b5886ce77713be2c332ec6a2fd0f028484ba
-            env:
-              XDG_DATA_HOME: &configDir /config
-              OP_HTTP_PORT: &apiPort 80
-              OP_BUS_PORT: 11220
-              OP_BUS_PEERS: localhost:11221
-              OP_SESSION:
-                valueFrom:
-                  secretKeyRef:
-                    name: onepassword-connect-secret
-                    key: 1password-credentials.json
-            probes:
-              liveness:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /heartbeat
-                    port: *apiPort
-                  initialDelaySeconds: 15
-                  periodSeconds: 30
-                  failureThreshold: 3
-              readiness:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /health
-                    port: *apiPort
-                  initialDelaySeconds: 15
-            securityContext: &securityContext
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
-            resources: &resources
-              requests:
-                cpu: 10m
-              limits:
-                memory: 256M
-          sync:
-            image:
-              repository: docker.io/1password/connect-sync
-              tag: 1.7.3@sha256:2f17621c7eb27bbcb1f86bbc5e5a5198bf54ac3b9c2ffac38064d03c932b07d5
-            env:
-              XDG_DATA_HOME: *configDir
-              OP_HTTP_PORT: &syncPort 8081
-              OP_BUS_PORT: 11221
-              OP_BUS_PEERS: localhost:11220
-              OP_SESSION:
-                valueFrom:
-                  secretKeyRef:
-                    name: onepassword-connect-secret
-                    key: 1password-credentials.json
-            probes:
-              liveness:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /heartbeat
-                    port: *syncPort
-                  initialDelaySeconds: 15
-                  periodSeconds: 30
-                  failureThreshold: 3
-              readiness:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /health
-                    port: *syncPort
-                  initialDelaySeconds: 15
-            securityContext: *securityContext
-            resources: *resources
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
-        fsGroupChangePolicy: OnRootMismatch
-        seccompProfile: { type: RuntimeDefault }
-    service:
-      app:
-        controller: onepassword-connect
-        ports:
-          http:
-            port: *apiPort
-    persistence:
-      config:
+    # Note: values.yaml files don't support templating out of the box, so that means
+    # that every value "{{ .Between.Curly.Braces }}" in this file needs to be
+    # explicitly interpolated on the template side by using the `tpl` function.
+
+    # global common labels, applied to all ressources
+    commonLabels: {}
+
+    # This section of values is for 1Password Connect API and Sync Configuration
+    connect:
+      # Denotes whether the 1Password Connect server will be deployed
+      create: true
+
+      # The number of replicas to run the 1Password Connect deployment
+      replicas: 1
+
+      # The 1Password Connect API Specific Values
+      api:
+        name: connect-api
+        # The 1Password Connect API repository
+        imageRepository: 1password/connect-api
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 0.2
+        httpPort: 8080
+        httpsPort: 8443
+        logLevel: info
+        # Prometheus Service Monitor
+        # ref: https://github.com/coreos/prometheus-operator
+        #
+        serviceMonitor:
+          # Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+          #
+          enabled: false
+          # Specify the interval at which metrics should be scraped
+          #
+          interval: 30s
+          # Define the path used by ServiceMonitor to scrape metrics
+          #
+          path: "/metrics"
+          # Define the HTTP URL parameters used by ServiceMonitor
+          #
+          params: {}
+          # Extra annotations for the ServiceMonitor
+          #
+          annotations: {}
+
+      # The 1Password Connect Sync Specific Values
+      sync:
+        name: connect-sync
+        imageRepository: 1password/connect-sync
+        resources: {}
+        httpPort: 8081
+        logLevel: info
+
+      # The name of 1Password Connect Application
+      applicationName: onepassword-connect
+
+      # The name of 1Password Connect Host
+      host: onepassword-connect
+
+      # The type of Service resource to create for the Connect API and sync services.
+      # See: https://kubernetes.io/docs/concepts/services-networking/service
+      # This by default is ClusterIP and can also be defined as NodePort or LoadBalancer.
+      # If serviceType is LoadBalancer then loadBalancerSourceRanges and loadBalancerIP should be defined.
+      # See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+      serviceType: ClusterIP
+
+      # Additional annotations to be added to the service resource
+      serviceAnnotations: {}
+
+      # loadBalancerSourceRanges:
+      #   - 10.0.0.0/16
+      #   - 1.84.26.4/32
+
+      # loadBalancerIP:
+
+      # The name of Kubernetes Secret containing the 1Password Connect credentials
+      credentialsName: onepassword-connect-secret
+
+      # The key for the 1Password Connect Credentials stored in the credentials secret
+      credentialsKey: 1password-credentials.json
+
+      # Contents of the 1password-credentials.json file for Connect.
+      # Can be set be adding --set-file connect.credentials=<path/to/1password-credentials.json>
+      # to your helm install command
+      credentials:
+
+      # Base64-encoded contents of the 1password-credentials.json file for Connect.
+      # This can be used instead of connect.credentials in case supplying raw JSON
+      # to connect.credentials leads to issues.
+      credentials_base64:
+
+      # The 1Password Connect API repository
+      imagePullPolicy: IfNotPresent
+
+      # List of secret names to use as image pull secrets. Secrets must exist in the same namespace.
+      imagePullSecrets: []
+
+      # The 1Password Connect version to pull
+      version: "{{ .Chart.AppVersion }}"
+
+      # Node selector stanza for the Connect pod
+      # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+      nodeSelector: {}
+
+      # Affinity rules for the Connect pod
+      affinity: {}
+
+      ## Horizontal Pod Autoscaling for the Connect pod
+      hpa:
+        # Enable Horizontal Pod Autoscaling for the Connect pod
+        enabled: false
+        # Additional annotations to be added to the HPA Connect
+        annotations: {}
+        # Minimum number of replicas for the Connect pod
+        minReplicas: 1
+        # Maximum number of replicas for the Connect pod
+        maxReplicas: 3
+        # Average Memory utilization percentage for the Connect pod
+        avgMemoryUtilization: 50
+        # Average CPU utilization percentage for the Connect pod
+        avgCpuUtilization: 50
+        # Defines the Autoscaling Behavior in up/down directions
+        behavior: {}
+
+      ## Pod Disruption Budget for the Connect pod
+      pdb:
+        # Enable Pod Disruption Budget for the Connect pod
+        enabled: false
+        # Additional annotations to be added to the PDB Connect
+        annotations: {}
+        # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
+        maxUnavailable: 1
+        # Number of pods that are available after eviction as number or percentage (eg.: 50%)
+        minAvailable: 0
+
+      # 1Password Connect API and Sync Service
+      probes:
+        # Denotes whether the 1Password Connect API readiness probe will operate
+        # and ensure the pod is ready before serving traffic
+        liveness: true
+        # Denotes whether the 1Password Connect API will be continually checked
+        # by Kubernetes for liveness and restarted if the pod becomes unresponsive
+        readiness: true
+
+      # priorityClassName to apply to the Connect API deployment resource.
+      priorityClassName: ''
+
+      # Additional annotations to be added to the Connect API deployment resource.
+      annotations: {}
+
+      # Additional labels to be added to the Connect API deployment resource.
+      labels: {}
+
+      # Additional annotations to be added to the Connect API pods.
+      podAnnotations: {}
+
+      # Additional labels to be added to the Connect API pods.
+      podLabels: {}
+
+      # List of tolerations to be added to the Connect API pods.
+      tolerations: []
+
+      # 1Password Connect volume shared between 1Password Connect Containers
+      dataVolume:
+        # The name of the shared volume used between 1Password Connect Containers
+        name: shared-data
+        # The type of the shared volume used between
+        # 1Password Connect Containers
         type: emptyDir
-        globalMounts:
-          - path: *configDir
+        # Desribes the fields and values for configuration of
+        # shared volume for 1Password Connect
+        values: {}
+
+      # Determines if HTTPS Port if setup for the 1Password Connect
+      # Services for 1Password Connect API and Sync
+      tls:
+        # Denotes whether the Connect API is secured with TLS
+        enabled: false
+        # The name of the secret containing the TLS key (tls.key) and certificate (tls.crt)
+        secret: op-connect-tls
+
+      # Ingress allows ingress services to be created to allow external access
+      # from Kubernetes to access 1Password Connect pods.
+      # In order to expose the service, use the route section below
+      ingress:
+        enabled: false
+        labels: {}
+          # traffic: external
+        annotations: {}
+          # |
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+          #   or
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+
+        # Optionally use ingressClassName instead of deprecated annotation.
+        # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+        ingressClassName: ""
+
+        # As of Kubernetes 1.19, all Ingress Paths must have a pathType configured. The default value below should be sufficient in most cases.
+        # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for other possible values.
+        pathType: Prefix
+        hosts:
+          - host: chart-example.local
+            paths: []
+        # Extra paths to prepend to the host configuration.
+        # This is useful when working with annotation based services.
+        extraPaths: []
+        # - path: /*
+        #   backend:
+        #     service:
+        #       name: ssl-redirect
+        #       port:
+        #         number: use-annotation
+        tls: []
+        #  - secretName: chart-example-tls
+        #    hosts:
+        #      - chart-example.local
+
+      # Optionally the internal profiler can be enabled to debug memory or performance issues.
+      # For normal operation of Connect this does not have to enabled.
+      profiler:
+        enabled: false
+        # The interval at which profiler snapshots are taken.
+        interval: 6h
+        # Number of profiler snapshots to keep.
+        keepLast: 12
+
+      # 1Password Connect Custom Container Environment Variables
+      # Must be written in the following format:
+      # - name: VARIABLE_NAME
+      #   value: VARIABLE_VALUE
+      customEnvVars: []
+
+    # This section of values is for 1Password Operator Configuration
+    operator:
+      # Denotes whether the 1Password Operator will be deployed
+      create: false
+
+      # Denotes authentication method that 1Password Operator will use to access 1Password secrets
+      # Valid values:
+      # - connect: sets OP_CONNECT_HOST and OP_CONNECT_TOKEN
+      # - service-account: sets OP_SERVICE_ACCOUNT_TOKEN
+      authMethod: connect
+
+      # The number of replicas to run the 1Password Connect Operator deployment
+      replicas: 1
+
+      # Denotes whether the 1Password Operator will automatically restart deployments based on associated updated secrets.
+      autoRestart: false
+
+      # The name of 1Password Operator Application
+      applicationName: onepassword-connect-operator
+
+      # The 1Password Operator image pull policy
+      imagePullPolicy: IfNotPresent
+
+      # List of secret names to use as image pull secrets. Secrets must exist in the same namespace.
+      imagePullSecrets: []
+
+      # The 1Password Operator repository
+      imageRepository: 1password/onepassword-operator
+
+      # How often the 1Password Operator will poll for secrets updates.
+      pollingInterval: 600
+
+      # The 1Password Operator version to pull
+      version: "1.9.1"
+
+      # Node selector stanza for the Operator pod
+      # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+      nodeSelector: {}
+
+      # Affinity rules for the Operator pod
+      affinity: {}
+
+      ## Horizontal Pod Autoscaling for the Operator pod
+      hpa:
+        # Enable Horizontal Pod Autoscaling for the Operator pod
+        enabled: false
+        # Additional annotations to be added to the HPA Operator
+        annotations: {}
+        # Minimum number of replicas for the Operator pod
+        minReplicas: 1
+        # Maximum number of replicas for the Operator pod
+        maxReplicas: 3
+        # Average Memory utilization percentage for the Operator pod
+        avgMemoryUtilization: 50
+        # Average CPU utilization percentage for the Operator pod
+        avgCpuUtilization: 50
+        # Defines the Autoscaling Behavior in up/down directions
+        behavior: {}
+
+      ## Pod Disruption Budget for the Operator pod
+      pdb:
+        # Enable Pod Disruption Budget for the Operator pod
+        enabled: false
+        # Additional annotations to be added to the PDB Operator
+        annotations: {}
+        # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
+        maxUnavailable: 1
+        # Number of pods that are available after eviction as number or percentage (eg.: 50%)
+        minAvailable: 0
+
+      # Additional annotations to be added to the Operator pods.
+      annotations: {}
+
+      # Additional labels to be added to the Operator deployment resource.
+      labels: {}
+
+      # Additional annotations to be added to the Operator pods.
+      podAnnotations: {}
+
+      # Additional labels to be added to the Operator pods.
+      podLabels: {}
+
+      # priorityClassName to apply to the Operator pods.
+      priorityClassName: ''
+
+      # List of tolerations to be added to the Operator pods.
+      tolerations: []
+
+      # A list of namespaces for the 1Password Operator to watch and manage. Use the empty list to watch all namespaces.
+      watchNamespace: []
+
+      # The resources requests/limits for the 1Password Operator pod
+      resources: {}
+
+      # 1Password Operator Connect Token Configuration
+      token:
+        # The name of Kubernetes Secret containing the 1Password Connect API token
+        name: onepassword-token
+
+        # The key for the 1Password Connect token stored in the 1Password token secret
+        key: token
+
+        # An API token generated for 1Password Connect to be used by the Operator
+        value:
+
+      # 1Password Service Account Token Configuration
+      serviceAccountToken:
+        # The name of Kubernetes Secret containing the 1Password Service Account token
+        name: onepassword-connect-token
+
+        # The key for the 1Password Service Account token stored in the 1Password token secret
+        key: token
+
+        # An API token generated for 1Password Service Account to be used by the Operator
+        value:
+
+      # 1Password Operator Service Account Configuration
+      serviceAccount:
+        # The name of the 1Password Conenct Operator
+        create: "{{ .Values.operator.create }}"
+
+        # Annotations for the 1Password Connect Service Account
+        annotations: {}
+
+        # The name of the 1Password Conenct Operator
+        name: onepassword-connect-operator
+
+      # 1Password Operator Role Binding Configuration
+      roleBinding:
+        # Denotes whether or not a role binding will be created for each Namespace for the 1Password Operator Service Account
+        create: "{{ .Values.operator.create }}"
+
+        # The name of the 1Password Operator Role Binding
+        name: onepassword-connect-operator
+
+      # 1Password Operator Cluster Role Configuration
+      clusterRole:
+        # Denotes whether or not a cluster role will be created for each for the 1Password Operator
+        create: "{{ .Values.operator.create }}"
+
+        # The name of the 1Password Operator Cluster Role
+        name: onepassword-connect-operator
+
+      # 1Password Operator Cluster Role Binding Configuration
+      clusterRoleBinding:
+        # Denotes whether or not a Cluster role binding will be created for the 1Password Operator Service Account
+        create: "{{ .Values.operator.create }}"
+
+        # The name of the 1Password Operator Cluster Role
+        name: onepassword-connect-operator
+
+      # 1Password Operator Log Level Configuration
+      logLevel: info
+
+      # 1Password Operator Custom Container Environment Variables
+      # Must be written in the following format:
+      # - name: VARIABLE_NAME
+      #   value: VARIABLE_VALUE
+      customEnvVars: []
+
+    # 1Password Acceptance Tests Functionality
+    acceptanceTests:
+      enabled: false
+      fixtures: {}
+      healthCheck:
+        enabled: true
+        image:
+          repository: curlimages/curl
+          tag: 'latest'

--- a/clusters/cluster0/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/clusters/cluster0/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   timeout: 15m
   chart:
     spec:
-      chart: vm/victoria-metrics-k8s-stack
+      chart: victoria-metrics-k8s-stack
       version: 0.60.1 
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
The original onepass chart was a borrowed from bjw-s of homeops and broke when updating. Since the official chart for 1pass is now fairly mature, I switched to it. Also attempted to fix an issue pulling victoria-metrics chart from the repo with a path adjustment.